### PR TITLE
Add multi arch support

### DIFF
--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,0 +1,6 @@
+SOURCE_URL=https://github.com/deluan/navidrome/releases/download/v0.30.1/navidrome_0.30.1_Linux_arm64.tar.gz
+SOURCE_SUM=ab788c6fd3f907e4a392978ea81f0d36546b3914ac3c7c83721e03ea2827c5ce
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=tar.gz
+SOURCE_IN_SUBDIR=false
+SOURCE_FILENAME=

--- a/conf/armv5.src
+++ b/conf/armv5.src
@@ -1,0 +1,6 @@
+SOURCE_URL=https://github.com/deluan/navidrome/releases/download/v0.30.1/navidrome_0.30.1_Linux_armv5.tar.gz
+SOURCE_SUM=17ca329f806d35aef2adf67f1d58800105d25fe455a8fbb1380f714a5c7a843f
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=tar.gz
+SOURCE_IN_SUBDIR=false
+SOURCE_FILENAME=

--- a/conf/armv6.src
+++ b/conf/armv6.src
@@ -1,0 +1,6 @@
+SOURCE_URL=https://github.com/deluan/navidrome/releases/download/v0.30.1/navidrome_0.30.1_Linux_armv6.tar.gz
+SOURCE_SUM=b9787f83be29cbb0bb5e1b17fb05b9490eccabf056c7a94f2790da16a44dbdb5
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=tar.gz
+SOURCE_IN_SUBDIR=false
+SOURCE_FILENAME=

--- a/conf/armv7.src
+++ b/conf/armv7.src
@@ -1,0 +1,6 @@
+SOURCE_URL=https://github.com/deluan/navidrome/releases/download/v0.30.1/navidrome_0.30.1_Linux_armv7.tar.gz
+SOURCE_SUM=222900948d5b0ef30604eb6a1126467f72c5dcb96b54c548d7c595cd2d38edd8
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=tar.gz
+SOURCE_IN_SUBDIR=false
+SOURCE_FILENAME=

--- a/conf/i386.src
+++ b/conf/i386.src
@@ -1,0 +1,6 @@
+SOURCE_URL=https://github.com/deluan/navidrome/releases/download/v0.30.1/navidrome_0.30.1_Linux_i386.tar.gz
+SOURCE_SUM=45972ab2c3254d724286060179c8bf77807feac7c612aa8107b0d56c89c7f518
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=tar.gz
+SOURCE_IN_SUBDIR=false
+SOURCE_FILENAME=

--- a/conf/x86-64.src
+++ b/conf/x86-64.src
@@ -1,0 +1,6 @@
+SOURCE_URL=https://github.com/deluan/navidrome/releases/download/v0.30.1/navidrome_0.30.1_Linux_x86_64.tar.gz
+SOURCE_SUM=4f5b8ecde66869ff550ac20d5cc2bcc27b69e5630e12935763d9ab4832cc110f
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=tar.gz
+SOURCE_IN_SUBDIR=false
+SOURCE_FILENAME=

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Modern Music Server and Streamer compatible with Subsonic/Airsonic",
         "fr": "Serveur de musique moderne et Streamer compatibles avec Subsonic/Airsonic"
     },
-    "version": "0.30.1~ynh2",
+    "version": "0.30.1~ynh3",
     "url": "https://github.com/deluan/navidrome/",
     "license": "AGPL-3.0-only",
     "maintainer": {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -19,6 +19,33 @@ pkg_dependencies="ffmpeg"
 # FUTURE OFFICIAL HELPERS
 #=================================================
 
+# Check the architecture
+#
+# example: architecture=$(ynh_detect_arch)
+#
+# usage: ynh_detect_arch
+#
+# Requires YunoHost version 2.2.4 or higher.
+ynh_detect_arch(){
+        local architecture
+        if [ -n "$(uname -m | grep arm64)" ] || [ -n "$(uname -m | grep aarch64)" ]; then
+                architecture="arm64"
+        elif [ -n "$(uname -m | grep 86)" ]; then
+                architecture="i386"                
+        elif [ -n "$(uname -m | grep 64)" ]; then
+                architecture="x86-64"
+        elif [ -n "$(uname -m | grep armv7)" ]; then
+                architecture="armv7"
+        elif [ -n "$(uname -m | grep armv6)" ]; then
+                architecture="armv6"
+        elif [ -n "$(uname -m | grep armv5)" ]; then
+                architecture="armv5"
+        else
+                architecture="unknown"
+        fi
+        echo $architecture
+}
+
 
 # Install or update the main directory yunohost.multimedia
 #

--- a/scripts/install
+++ b/scripts/install
@@ -26,6 +26,7 @@ ynh_abort_if_errors
 domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
 is_public=$YNH_APP_ARG_IS_PUBLIC
+architecture=$(ynh_detect_arch)
 
 app=$YNH_APP_INSTANCE_NAME
 
@@ -83,7 +84,7 @@ ynh_script_progression --message="Setting up source files..." --weight=4
 ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 
 # Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source --dest_dir=$final_path
+ynh_setup_source --dest_dir=$final_path --source_id="$architecture"
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -21,6 +21,7 @@ path_url=$(ynh_app_setting_get --app=$app --key=path)
 is_public=$(ynh_app_setting_get --app=$app --key=is_public)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 port=$(ynh_app_setting_get --app=$app --key=port)
+architecture=$(ynh_detect_arch)
 
 #=================================================
 # CHECK VERSION
@@ -64,7 +65,7 @@ then
 	ynh_secure_remove --file=$final_path
 
 	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir=$final_path
+	ynh_setup_source --dest_dir=$final_path --source_id="$architecture"
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -60,12 +60,23 @@ ynh_systemd_action --service_name=$app --action="stop" --log_path="systemd"
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=5
+
+	# # Create a temporary directory
+	# tmpdir="$(mktemp -d)"
+	# # Backup the config file in the temp dir
+	# cp -a "/var/lib/$app/navidrome.toml" "$tmpdir/navidrome.toml"
 	
 	# Remove the app directory securely
 	ynh_secure_remove --file=$final_path
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	ynh_setup_source --dest_dir=$final_path --source_id="$architecture"
+
+	# # Copy the admin saved settings from tmp directory to final config path	
+	# cp -a "$tmpdir/navidrome.toml" "/var/lib/$app/navidrome.toml" 
+
+	# # Remove the tmp directory securely
+	# ynh_secure_remove --file="$tmpdir"
 fi
 
 #=================================================
@@ -104,21 +115,21 @@ ynh_multimedia_addfolder --source_dir="/home/yunohost.$app/Music" --dest_dir="sh
 #=================================================
 # MODIFY A CONFIG FILE
 #=================================================
-ynh_script_progression --message="Modifying a config file..."
+# ynh_script_progression --message="Modifying a config file..."
 
-config_path="/var/lib/$app"
-mkdir -p "$config_path"
+# config_path="/var/lib/$app"
+# mkdir -p "$config_path"
 
-ynh_backup_if_checksum_is_different --file="$config_path/navidrome.toml"
+# ynh_backup_if_checksum_is_different --file="$config_path/navidrome.toml"
 
-cp ../conf/navidrome.toml "$config_path/navidrome.toml"
+# cp ../conf/navidrome.toml "$config_path/navidrome.toml"
 
-# Main config File
-ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file="$config_path/navidrome.toml"
-ynh_replace_string --match_string="__PATH_URL__" --replace_string="$path_url" --target_file="$config_path/navidrome.toml"
-ynh_replace_string --match_string="__CONFIG_PATH__" --replace_string="$config_path" --target_file="$config_path/navidrome.toml"
+# # Main config File
+# ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file="$config_path/navidrome.toml"
+# ynh_replace_string --match_string="__PATH_URL__" --replace_string="$path_url" --target_file="$config_path/navidrome.toml"
+# ynh_replace_string --match_string="__CONFIG_PATH__" --replace_string="$config_path" --target_file="$config_path/navidrome.toml"
 
-ynh_store_file_checksum --file="$config_path/navidrome.toml"
+# ynh_store_file_checksum --file="$config_path/navidrome.toml"
 
 #=================================================
 # SETUP SYSTEMD

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -117,7 +117,7 @@ ynh_multimedia_addfolder --source_dir="/home/yunohost.$app/Music" --dest_dir="sh
 #=================================================
 # ynh_script_progression --message="Modifying a config file..."
 
-# config_path="/var/lib/$app"
+config_path="/var/lib/$app"
 # mkdir -p "$config_path"
 
 # ynh_backup_if_checksum_is_different --file="$config_path/navidrome.toml"


### PR DESCRIPTION
## Problem
- *Binaries install for x86-64 architecture only*

## Solution
- *Add Install binaries for armv5, armv6, armv7, i386*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/navidrome_ynh%20PR13%20(ericgaspar)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/navidrome_ynh%20PR13%20(ericgaspar)/)  
