### PR TITLE
Add documentation explaining how Navidrome is accessed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Navidrome indexes all digital music stored in your hard drive and makes it avail
 - Transcoding on the fly. Can be set per user/player. Opus encoding is supported
 
 
-**Shipped version:** 0.50.0~ynh1
+**Shipped version:** 0.50.0~ynh2
 
 **Demo:** https://demo.navidrome.org/app/#/login
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -31,7 +31,7 @@ Navidrome indexe toute la musique numérique stockée sur votre disque dur et la
 - Compatible avec tous les clients subsonique/madsononique/aironique
 - Encodage à la volée. Peut être défini par utilisateur/lecteur. Le codage opus est pris en charge 
 
-**Version incluse :** 0.50.0~ynh1
+**Version incluse :** 0.50.0~ynh2
 
 **Démo :** https://demo.navidrome.org/app/#/login
 

--- a/conf/navidrome.toml
+++ b/conf/navidrome.toml
@@ -26,7 +26,7 @@ TranscodingCacheSize = "150MB"
 ImageCacheSize = "100MB"
 
 # Folder to store application data (DB, cache…)
-DataFolder = "__CONFIG_PATH__"
+DataFolder = "/var/lib/__APP__/"
 
 # Folder where your music library is stored. Can be read-only
 MusicFolder = "/home/yunohost.multimedia/share/Music"

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -6,9 +6,8 @@ You can configure an alternative path to you music files by editing the path `Mu
 
 #### Accessing Navidrome
 
-Navidrome uses its own password database and does not integrate with Yunohost LDAP, so there are two ways to access it:
+Navidrome uses its own password database and does not integrate with YunoHost LDAP, so there are two ways to access it:
 
-- When Navidrome is initially installed, before any users log in there is an option to create a Navidrome admin user by going directly to the access URL set for Navidrome in Yunohost. This admin account can create users who are able to log in via the same access URL.
-- The second method to access Navidrome is via Yunohost SSO, which is accomplished by logging in to Yunohost and then clicking on the Navidrome tile. With this method, the Navidrome password database is not populated with the Yunohost password which means future attempts to log in to Navidrome directly via the access URL will fail. This prevents alternative clients from logging in with the Yunohost user credentials, so in order to work around this issue, after logging in to Navidrome with SSO the user password can be manually set via the Navidrome interface. Any password will be accepted as the current password.
+- When Navidrome is initially installed, before any users log in there is an option to create a Navidrome admin user by going directly to the access URL set for Navidrome in YunoHost. This admin account can create users who are able to log in via the same access URL.
+- The second method to access Navidrome is via YunoHost SSO, which is accomplished by logging in to YunoHost and then clicking on the Navidrome tile. With this method, the Navidrome password database is not populated with the YunoHost password which means future attempts to log in to Navidrome directly via the access URL will fail. This prevents alternative clients from logging in with the YunoHost user credentials, so in order to work around this issue, after logging in to Navidrome with SSO the user password can be manually set via the Navidrome interface. Any password will be accepted as the current password.
 
-Further explanation of this can be found in [this github issue](https://github.com/YunoHost-Apps/navidrome_ynh/issues/101).

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -3,3 +3,12 @@
 Your music files are stored by default in your shared [multimedia folder](https://github.com/YunoHost-Apps/yunohost.multimedia) `/home/yunohost.multimedia/share/Music`. This folder is accessible from Nextcloud with *External Storages* enabled. This will allow you to easily upload your music files to the server.
 
 You can configure an alternative path to you music files by editing the path `MusicFolder = "/home/yunohost.multimedia/share/Music"` in this file `/var/lib/navidrome/navidrome.toml` using the [documentation](https://www.navidrome.org/docs/usage/configuration-options/). Remember to restart Navidrome service if you change your configuration file.
+
+#### Accessing Navidrome
+
+Navidrome uses its own password database and does not integrate with Yunohost LDAP, so there are two ways to access it:
+
+- When Navidrome is initially installed, before any users log in there is an option to create a Navidrome admin user by going directly to the access URL set for Navidrome in Yunohost. This admin account can create users who are able to log in via the same access URL.
+- The second method to access Navidrome is via Yunohost SSO, which is accomplished by logging in to Yunohost and then clicking on the Navidrome tile. With this method, the Navidrome password database is not populated with the Yunohost password which means future attempts to log in to Navidrome directly via the access URL will fail. This prevents alternative clients from logging in with the Yunohost user credentials, so in order to work around this issue, after logging in to Navidrome with SSO the user password can be manually set via the Navidrome interface. Any password will be accepted as the current password.
+
+Further explanation of this can be found in [this github issue](https://github.com/YunoHost-Apps/navidrome_ynh/issues/101).

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Navidrome"
 description.en = "Modern Music Server and Streamer compatible with Subsonic/Airsonic"
 description.fr = "Serveur de musique moderne et Streamer compatibles avec Subsonic/Airsonic"
 
-version = "0.50.0~ynh1"
+version = "0.50.0~ynh2"
 
 maintainers = ["eric_G"]
 


### PR DESCRIPTION
After installing Navidrome it is not immediately clear how users are populated and accessed so this adds a few sentences describing how it works both from Yunohost SSO and alternative client perspectives.

## Problem

After installing Navidrome and logging in with SSO, I was unable to log in until I manually set the user password. I didn't realize this was the solution until I went searching through the github issues.

## Solution

I've added some documentation so hopefully it's more clear for other users, without having to go through github issues.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
