### PR TITLE
fix: allow sso with yunohost 12

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,6 +8,7 @@ location __PATH__/ {
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Host $server_name;
+  proxy_set_header Remote-User $remote_user;
 
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
## Problem

- After uprading to yunohost 12, I am unable to connect to navidrome. I am redirected to a navidrome login page.

## Solution

- add `Remote-User` header for requests proxied by yunohost

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
